### PR TITLE
v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the pulp_server cookbook.
 
+## 0.1.2 (2017-07-18)
+
+- Fixes server.conf location in default recipe
+- Fixes messaging and task broker urls in default server config
+
 ## 0.1.1 (2017-07-14)
 
 - Changelog file created

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,7 +81,7 @@ default['pulp_server']['config']['data_reaping'] = {
   'task_result_history' => 3
 }
 default['pulp_server']['config']['messaging'] = {
-  'url' => 'tcp',
+  'url' => 'tcp://localhost:5672',
   'transport' => 'qpid',
   'auth_enabled' => 'true',
   'cacert' => '/etc/pki/qpid/ca/ca.crt',
@@ -91,7 +91,7 @@ default['pulp_server']['config']['messaging'] = {
   'event_notification_url' => 'qpid'
 }
 default['pulp_server']['config']['tasks'] = {
-  'broker_url' => 'qpid',
+  'broker_url' => 'qpid://localhost/',
   'celery_require_ssl' => false,
   'cacert' => '/etc/pki/pulp/qpid/ca.crt',
   'keyfile' => '/etc/pki/pulp/qpid/client.crt',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'liudasbk@users.noreply.github.com'
 license 'MIT'
 description 'Installs/Configures pulp_server'
 long_description 'Installs/Configures pulp_server'
-version '0.1.1'
+version '0.1.2'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url 'https://github.com/liudasbk/pulp-server-cookbook/issues'
 source_url 'https://github.com/liudasbk/pulp-server-cookbook'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,13 +50,7 @@ directory '/etc/pulp' do
   mode 0o0755
 end
 
-directory '/etc/pulp/server' do
-  owner 'root'
-  group 'root'
-  mode 0o0755
-end
-
-template '/etc/pulp/server/server.conf' do
+template '/etc/pulp/server.conf' do
   source 'server.conf.erb'
   owner 'root'
   group 'apache'


### PR DESCRIPTION
## v0.1.2 release

Fixes server.conf location (/etc/pulp/server.conf instead of /etc/pulp/server/server.conf).
Fixes messaging and tasks broker url in default attributes