### PR TITLE
Pulp 2.18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # pulp_server Cookbook CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 (2019-01-27)
+
+### Changed
+- `python-qpid` package is replaced with `python2-qpid` (JustinasKO)
+- Default Pulp version to 2.18
+
 ## 0.2.1 (2018-01-04)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ More information:
 
 ## Attributes
 
-- `node['pulp_server']['version']` - Specifies Pulp server version. It is used to configure pulp yum repository. Default: `2.13`.
+- `node['pulp_server']['version']` - Specifies Pulp server version. It is used to configure pulp yum repository. Default: `2.18`.
 - `node['pulp_server']['configure_repos']` - If true, setup yum repository for pulp server installation. Default: true.
-- `node['pulp_server']['install_baseurl']` - baseurl to use in pulp server installation repository configuration. Default: `https://repos.fedorapeople.org/repos/pulp/pulp/stable/2.11/$releasever/$basearch/`.
+- `node['pulp_server']['install_baseurl']` - baseurl to use in pulp server installation repository configuration. Default: `https://repos.fedorapeople.org/repos/pulp/pulp/stable/2.18/$releasever/$basearch/`.
 - `node['pulp_server']['install_gpgkey']` - gpgkey to use in pulp server installation repository configuration. Default: `https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2`.
 - `node['pulp_server']['configure_epel']` - If true, setup yum repository for EPEL, this is required for mongodb, qpid and other dependencies. Set to false if repository is configured by other means (for example epel cookbook). Default: true.
 - `node['pulp_server']['epel_mirrorlist']` - mirrorlist to use in EPEL repository configuration. Defalt: `http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 
-default['pulp_server']['version'] = '2.13'
+default['pulp_server']['version'] = '2.18'
 
 # Pulp install repository
 default['pulp_server']['configure_repos'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'liudasbk@users.noreply.github.com'
 license 'MIT'
 description 'Installs/Configures pulp_server'
 long_description 'Installs/Configures pulp_server'
-version '0.2.1'
+version '0.3.0'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url 'https://github.com/liudasbk/pulp-server-cookbook/issues'
 source_url 'https://github.com/liudasbk/pulp-server-cookbook'

--- a/recipes/qpid.rb
+++ b/recipes/qpid.rb
@@ -27,7 +27,7 @@
 package %w[qpid-cpp-server
            qpid-cpp-server-linearstore
            python-gofer-qpid
-           python-qpid
+           python2-qpid
            qpid-tools]
 
 service 'qpidd' do

--- a/test/smoke/default/repos_test.rb
+++ b/test/smoke/default/repos_test.rb
@@ -5,7 +5,7 @@
 # The Inspec reference, with examples and extensive documentation, can be
 # found at http://inspec.io/docs/reference/resources/
 
-describe file('/etc/yum.repos.d/pulp-2.13-stable.repo') do
+describe file('/etc/yum.repos.d/pulp-2.18-stable.repo') do
   it { should be_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'root' }
@@ -20,7 +20,7 @@ describe file('/etc/yum.repos.d/epel.repo') do
 end
 
 describe command('yum repolist --disablerepo=*' \
-                 '--enablerepo=pulp-2.13-stable') do
+                 '--enablerepo=pulp-2.18-stable') do
   its('exit_status') { should eq 0 }
 end
 


### PR DESCRIPTION
- Changes default Pulp server version to 2.18
- Replaces `python-qpid` package with `python2-qpid` as `python-qpid` is being deprecated and will be removed from future CentOS / RHEL releases.