### PR TITLE
Ensures Pulp services are stopped before running managedb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # pulp_server Cookbook CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## 0.3.1 (2019-01-28)
+
+### Fixed
+- managedb failure when Pulp services are running
+
 ## 0.3.0 (2019-01-27)
 
 ### Changed

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'liudasbk@users.noreply.github.com'
 license 'MIT'
 description 'Installs/Configures pulp_server'
 long_description 'Installs/Configures pulp_server'
-version '0.3.0'
+version '0.3.1'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url 'https://github.com/liudasbk/pulp-server-cookbook/issues'
 source_url 'https://github.com/liudasbk/pulp-server-cookbook'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,9 @@ execute 'pulp-manage-db' do
   command 'su apache -s /bin/bash -c "/usr/bin/pulp-manage-db"'
   not_if 'su apache -s /bin/bash -c "/usr/bin/pulp-manage-db --dry-run"'
   notifies :restart, 'service[httpd]', :delayed
+  notifies :stop, 'service[pulp_workers]', :before
+  notifies :stop, 'service[pulp_celerybeat]', :before
+  notifies :stop, 'service[pulp_resource_manager]', :before
 end
 
 execute 'pulp-gen-ca-certificate' do


### PR DESCRIPTION
Ensures Pulp services are stopped before running `managedb` (https://github.com/liudasbk/pulp-server-cookbook/issues/10)